### PR TITLE
Perf: Take iron-meta out of render tree

### DIFF
--- a/iron-meta.html
+++ b/iron-meta.html
@@ -110,6 +110,10 @@ Or, in a Polymer element, you can include a meta in your template:
 
       },
 
+      hostAttributes: {
+        hidden: true
+      },
+
       /**
        * Only runs if someone invokes the factory/constructor directly
        * e.g. `new Polymer.IronMeta()`


### PR DESCRIPTION
R: @sjmiles @sorvell @kevinpschaaf 

There's no reason this element should be in the render tree.