### PR TITLE
actual docs for byKey

### DIFF
--- a/iron-meta.html
+++ b/iron-meta.html
@@ -33,17 +33,17 @@ attributes or use child nodes to define additional metadata.
 Now I can access that element (and it's metadata) from any iron-meta instance
 via the byKey method, e.g.
 
-    meta.byKey('info').getAttribute('value');
+    meta.byKey('info');
 
 Pure imperative form would be like:
 
-    document.createElement('iron-meta').byKey('info').getAttribute('value');
+    document.createElement('iron-meta').byKey('info');
 
 Or, in a Polymer element, you can include a meta in your template:
 
     <iron-meta id="meta"></iron-meta>
     ...
-    this.$.meta.byKey('info').getAttribute('value');
+    this.$.meta.byKey('info');
 
 @group Iron Elements
 @demo demo/index.html


### PR DESCRIPTION
The API seems to be different from what explained in the docs.

`meta.byKey('info').getAttribute('value');` results in a `getAttribute() is not a function` error.

I'm therefore truncating the code to `meta.byKey('info')` which seems to return the actual value.