### PR TITLE
Make iron-meta.html ES5 compatible

### DIFF
--- a/iron-meta.html
+++ b/iron-meta.html
@@ -99,7 +99,7 @@ Or, in a Polymer element, you can include a meta in your template:
         }
       },
 
-      byKey(key) {
+      byKey: function(key) {
         this.key = key;
         return this.value;
       }
@@ -158,7 +158,7 @@ Or, in a Polymer element, you can include a meta in your template:
       },
 
       __computeMeta: function(type, key, value) {
-        let meta = new Polymer.IronMeta({
+        var meta = new Polymer.IronMeta({
           type: type,
           key: key
         });


### PR DESCRIPTION
`iron-meta.html` had 2 pieces of code using a syntax introduced in ES2015, and thus not compatible with ES5. As not everyone consuming the hybrid elements has an ES2015 conversion pipeline setup, it would be great if elements could stick to ES5 syntax.

If this is not a goal, feel free to close this PR.