### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/iron-meta.js
+++ b/iron-meta.js
@@ -135,6 +135,7 @@ Or, in a Polymer element, you can include a meta in your template:
 Polymer({
 
   is: 'iron-meta',
+  _template: null,
 
   properties: {
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336